### PR TITLE
fix(components.ts): make components accessible externally

### DIFF
--- a/src/constants/components.ts
+++ b/src/constants/components.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-const enum COMPONENTS {
+enum COMPONENTS {
   aggregator = 'aggregator',
   button = 'button',
   link = 'link'


### PR DESCRIPTION
Remove the const from the enum as we need to make it accessible externally.
When a const is available in front of the enum, TS compiler will by default remove the entire listing of components from the resulting build.

This would mean when the package is used externally no one can access components.