### PR TITLE
feat: export main types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,5 +17,10 @@ import TrackingRoot from './components/TrackingRoot';
 import TrackingView from './components/TrackingView';
 import TrackingZone from './components/TrackingZone';
 import useClickTrigger from './hooks/useClickTrigger';
+import * as Types from './types';
 
 export { TrackingRoot, TrackingView, TrackingZone, useClickTrigger };
+
+export type Dispatch = Types.Dispatch;
+export type Events = Types.Events;
+export type Payload = Types.Payload;


### PR DESCRIPTION
The `Dispatch`, `Events`, and `Payload` types are likely to be needed by users of Collector, so it makes sense to make them available as top-level exports. 

See https://github.com/sumup-oss/circuit-ui/pull/598#discussion_r433809563