### PR TITLE
feat(elementTree): add elementTree to event schema

### DIFF
--- a/src/components/TrackingContext/TrackingContext.tsx
+++ b/src/components/TrackingContext/TrackingContext.tsx
@@ -20,7 +20,7 @@ import { TrackingContextKeys as ContextKeys } from '../../types';
 const TrackingContext = React.createContext<ContextKeys>({
   app: undefined,
   view: undefined,
-  zone: undefined
+  elementTree: []
 });
 
 export default TrackingContext;

--- a/src/components/TrackingElement/TrackingElement.spec.tsx
+++ b/src/components/TrackingElement/TrackingElement.spec.tsx
@@ -21,7 +21,7 @@ import TrackingRoot from '../TrackingRoot';
 import TrackingView from '../TrackingView';
 import useClickTrigger from '../../hooks/useClickTrigger';
 
-import TrackingZone from './TrackingZone';
+import TrackingElement from './TrackingElement';
 
 interface DispatchButton {
   testId?: string;
@@ -44,19 +44,19 @@ const DispatchButton = ({ testId = 'dispatch-btn' }: DispatchButton) => {
   );
 };
 
-describe('Zone', () => {
-  it('should attach the zone property when dispatching an event', () => {
+describe('Element', () => {
+  it('should attach the element property when dispatching an event', () => {
     const dispatch = jest.fn();
     const app = '';
     const view = 'test';
-    const zone = 'test-zone-spec';
+    const element = 'test-element-spec';
     const btn = 'dispatch-btn';
     const component = 'button';
 
     const expected = {
       app,
       view,
-      zone,
+      elementTree: [element],
       event: Events.click,
       component,
       label: undefined,
@@ -65,10 +65,10 @@ describe('Zone', () => {
 
     const { getByTestId } = render(
       <TrackingRoot name={app} onDispatch={dispatch}>
-        <TrackingView name="test">
-          <TrackingZone name={zone}>
+        <TrackingView name={view}>
+          <TrackingElement name={element}>
             <DispatchButton />
-          </TrackingZone>
+          </TrackingElement>
         </TrackingView>
       </TrackingRoot>
     );
@@ -79,56 +79,68 @@ describe('Zone', () => {
   });
 });
 
-describe('Nested Zones', () => {
-  it('Button located within nested zones A & B dispatching their immediate parent zone name', () => {
+describe('Nested Elements', () => {
+  it('should properly nest the elements in the elementTree per "branch"', () => {
     const dispatch = jest.fn();
     const app = 'test-app-spec';
     const view = 'test-view-spec';
     const component = 'button';
-    const zoneA = 'test-zone-spec A';
-    const zoneB = 'test-zone-spec B';
+
+    const elementA = 'test-element-spec A';
+    const elementB = 'test-element-spec B';
+    const elementC = 'test-element-spec C';
+
     const btnA = 'dispatch-btn-a';
     const btnB = 'dispatch-btn-b';
+    const btnC = 'dispatch-btn-c';
 
-    const expectedForZoneB = {
+    const expectedForElementA = {
       app,
       view,
-      zone: zoneB,
+      elementTree: [elementA],
       event: Events.click,
       component,
       label: undefined,
       timestamp: expect.any(Number)
     };
 
-    const expectedForZoneA = {
-      app,
-      view,
-      zone: zoneA,
-      event: Events.click,
-      component,
-      label: undefined,
-      timestamp: expect.any(Number)
+    const expectedForElementB = {
+      ...expectedForElementA,
+      elementTree: [elementA, elementB]
+    };
+
+    const expectedForElementC = {
+      ...expectedForElementA,
+      elementTree: [elementA, elementC]
     };
 
     const { getByTestId } = render(
       <TrackingRoot name={app} onDispatch={dispatch}>
         <TrackingView name={view}>
-          <TrackingZone name={zoneA}>
+          <TrackingElement name={elementA}>
             <DispatchButton testId={btnA} />
-            <TrackingZone name={zoneB}>
+            <TrackingElement name={elementB}>
               <DispatchButton testId={btnB} />
-            </TrackingZone>
-          </TrackingZone>
+            </TrackingElement>
+
+            <TrackingElement name={elementC}>
+              <DispatchButton testId={btnC} />
+            </TrackingElement>
+          </TrackingElement>
         </TrackingView>
       </TrackingRoot>
     );
 
     fireEvent.click(getByTestId(btnA));
 
-    expect(dispatch).toHaveBeenCalledWith(expectedForZoneA);
+    expect(dispatch).toHaveBeenCalledWith(expectedForElementA);
 
     fireEvent.click(getByTestId(btnB));
 
-    expect(dispatch).toHaveBeenCalledWith(expectedForZoneB);
+    expect(dispatch).toHaveBeenCalledWith(expectedForElementB);
+
+    fireEvent.click(getByTestId(btnC));
+
+    expect(dispatch).toHaveBeenCalledWith(expectedForElementC);
   });
 });

--- a/src/components/TrackingElement/TrackingElement.tsx
+++ b/src/components/TrackingElement/TrackingElement.tsx
@@ -18,12 +18,12 @@ import * as React from 'react';
 import { TrackingProviderProps as ProviderProps } from '../../types';
 import TrackingContext from '../TrackingContext';
 
-const TrackingZone = ({ name, children }: ProviderProps) => {
+const TrackingElement = ({ name, children }: ProviderProps) => {
   const baseContext = React.useContext(TrackingContext);
   const contextValue = React.useMemo(
     () => ({
       ...baseContext,
-      zone: name
+      elementTree: [...baseContext.elementTree, name]
     }),
     [baseContext, name]
   );
@@ -35,4 +35,4 @@ const TrackingZone = ({ name, children }: ProviderProps) => {
   );
 };
 
-export default TrackingZone;
+export default TrackingElement;

--- a/src/components/TrackingElement/index.ts
+++ b/src/components/TrackingElement/index.ts
@@ -13,6 +13,6 @@
  * limitations under the License.
  */
 
-import TrackingZone from './TrackingZone';
+import TrackingElement from './TrackingElement';
 
-export default TrackingZone;
+export default TrackingElement;

--- a/src/components/TrackingRoot/TrackingRoot.spec.tsx
+++ b/src/components/TrackingRoot/TrackingRoot.spec.tsx
@@ -48,7 +48,7 @@ describe('Root', () => {
     const expected = {
       app,
       view: undefined,
-      zone: undefined,
+      elementTree: [],
       event: Events.click,
       component,
       label: undefined,

--- a/src/components/TrackingRoot/TrackingRoot.tsx
+++ b/src/components/TrackingRoot/TrackingRoot.tsx
@@ -26,6 +26,7 @@ const TrackingRoot = ({ name, onDispatch, children }: Props) => {
   const contextValue = React.useMemo(
     () => ({
       app: name,
+      elementTree: [],
       dispatch: onDispatch
     }),
     [name, onDispatch]

--- a/src/components/TrackingView/TrackingView.spec.tsx
+++ b/src/components/TrackingView/TrackingView.spec.tsx
@@ -50,7 +50,7 @@ describe('View', () => {
     const expected = {
       app,
       view,
-      zone: undefined,
+      elementTree: [],
       event: Events.click,
       component,
       label: undefined,

--- a/src/hooks/useBaseTrigger/useBaseTrigger.spec.tsx
+++ b/src/hooks/useBaseTrigger/useBaseTrigger.spec.tsx
@@ -39,7 +39,7 @@ const DispatchButton = () => {
 };
 
 describe('useBaseTrigger', () => {
-  it('should provide a dispatch function that accepts a label and a component, and attaches the app/view/zone/event/timestamp to the dispatched event', () => {
+  it('should provide a dispatch function that accepts a label and a component, and attaches the app/view/elementTree/event/timestamp to the dispatched event', () => {
     const dispatch = jest.fn();
     const app = 'test-app-hook';
     const btn = 'dispatch-btn';
@@ -48,7 +48,7 @@ describe('useBaseTrigger', () => {
     const expected = {
       app,
       view: undefined,
-      zone: undefined,
+      elementTree: [],
       event: Events.click,
       component,
       id: undefined,

--- a/src/hooks/useBaseTrigger/useBaseTrigger.ts
+++ b/src/hooks/useBaseTrigger/useBaseTrigger.ts
@@ -19,14 +19,16 @@ import TrackingContext from '../../components/TrackingContext';
 import { Events, Dispatch } from '../../types';
 
 const useBaseTrigger = (event: Events) => {
-  const { dispatch, app, view, zone } = React.useContext(TrackingContext);
+  const { dispatch, app, view, elementTree } = React.useContext(
+    TrackingContext
+  );
 
   return ({ component, label, customParameters }: Dispatch) =>
     dispatch &&
     dispatch({
       app,
       view,
-      zone,
+      elementTree,
       event,
       component,
       label,

--- a/src/hooks/useClickTrigger/useClickTrigger.spec.tsx
+++ b/src/hooks/useClickTrigger/useClickTrigger.spec.tsx
@@ -48,7 +48,7 @@ describe('useClickTrigger', () => {
     const expected = {
       app,
       view: undefined,
-      zone: undefined,
+      elementTree: [],
       event: Events.click,
       component,
       id: undefined,

--- a/src/hooks/usePageActiveTrigger/usePageActiveTrigger.spec.tsx
+++ b/src/hooks/usePageActiveTrigger/usePageActiveTrigger.spec.tsx
@@ -36,6 +36,7 @@ describe('usePageActiveTrigger', () => {
       const expected = {
         app,
         event: Events.pageView,
+        elementTree: [],
         timestamp: expect.any(Number)
       };
 

--- a/src/hooks/usePageViewTrigger/usePageViewTrigger.spec.tsx
+++ b/src/hooks/usePageViewTrigger/usePageViewTrigger.spec.tsx
@@ -40,6 +40,7 @@ describe('usePageViewTrigger', () => {
     const expected = {
       app,
       event: Events.pageView,
+      elementTree: [],
       timestamp: expect.any(Number)
     };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,11 +15,11 @@
 
 import TrackingRoot from './components/TrackingRoot';
 import TrackingView from './components/TrackingView';
-import TrackingZone from './components/TrackingZone';
+import TrackingElement from './components/TrackingElement';
 import useClickTrigger from './hooks/useClickTrigger';
 import * as Types from './types';
 
-export { TrackingRoot, TrackingView, TrackingZone, useClickTrigger };
+export { TrackingRoot, TrackingView, TrackingElement, useClickTrigger };
 
 export type Dispatch = Types.Dispatch;
 export type Events = Types.Events;

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+type ElementTree = string[];
+
 export enum Events {
   click = 'click',
   view = 'view',
@@ -25,13 +27,13 @@ export enum Events {
 export interface Payload {
   app: string | undefined;
   view: string | undefined;
-  zone?: string;
+  elementTree: ElementTree;
   component?: string;
   label?: string;
   event: Events;
   timestamp: number;
   customParameters?: {
-    [key: string]: any;
+    [key: string]: unknown;
   };
 }
 
@@ -39,14 +41,14 @@ export interface Dispatch {
   component?: string;
   label?: string;
   customParameters?: {
-    [key: string]: any;
+    [key: string]: unknown;
   };
 }
 
 export interface TrackingContextKeys {
   app?: string;
   view?: string;
-  zone?: string;
+  elementTree: ElementTree;
   dispatch?: (e: Payload) => void;
   setView?: (view: string) => void;
 }


### PR DESCRIPTION
# Changes

## We are introducing a new property to the event schema called `elementTree`
The `elementTree` is an array of strings to help consumers enhance their events to retrace how the tree was looking like when an event was dispatched (IE is this button clicking coming from which parent? The header of the footer?)

In order to control which items are added to the `elementTree`, we also introduced a new component called `TrackingElement`. here's one quick example of it in action:

```jsx
<TrackingElement name="top-section">
  <TrackingElement name="hero">  
    <ButtonWithClickTrigger>Click me!</ButtonWithClickTrigger>
  </TrackingElement>
</TrackingElement>

// when clicked, will result in
{
  elementTree: ['top-section', 'hero']
}

<TrackingElement name="footer">
  <TrackingElement name="social-widgets">
    <ButtonWithClickTrigger>Click me!</ButtonWithClickTrigger>
  </TrackingElement>
</TrackingElement>

// when clicked, will result in
{
  elementTree: ['footer', 'social-widgets']
}
```

At first sight, this might seem very similar to a previous concept we introduced called `Zones/TrackingZone`. In fact, you can consider the `elementTree` a super powerful zone! (Which allows you to store the whole tree down until the dispatched event).

## Zones/TrackingZones are removed in favor of the elementTree concept
Since we weren't using `Zones` yet, and the `elementTree` is very powerful, we've decided to remove it from the project entirely.

Looking forward to hearing your thoughts @connor-baer @lucent1090 