### PR TITLE
feat(usesubmittrigger): add useSubmitTrigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Collector is a library of React components and hooks that facilitates contextual
   - [TrackingView](#trackingview)
   - [TrackingElement](#trackingelement)
   - [useClickTrigger](#useclicktrigger)
+  - [useSubmitTrigger](#usesubmittrigger)
   - [usePageViewTrigger](#usepageviewtrigger)
 - [Code of Conduct (CoC)](#code-of-conduct-coc)
   - [Maintainers](#maintainers)
@@ -260,6 +261,41 @@ function Button({ onClick, 'tracking-label': label, children }) {
   }
 
   return <button onClick={handler}>{children}</button>;
+}
+```
+
+### useSubmitTrigger
+
+`useSubmitTrigger` provides you a dispatch function for any kind of form submission event.
+
+The dispatch function accepts the following interface:
+
+```jsx
+interface Options {
+  component?: string;
+  label?: string;
+  customParameters?: {
+    [key: string]: any
+  };
+  event: 'submit'; // Added internally by the hook
+  timestamp: number; // Added internally when the dispatch function is called
+}
+```
+
+```jsx
+import React from 'react';
+import { useSubmitTrigger } from '@sumup/collector';
+
+function Form({ children }) {
+  const dispatch = useSubmitTrigger();
+
+  const submitHandler = (e) => {
+    e.preventDefault();
+
+    dispatch({ component: 'form' });
+  };
+
+  return <form onSubmit={handler}>{children}</form>;
 }
 ```
 

--- a/src/hooks/useSubmitTrigger/index.ts
+++ b/src/hooks/useSubmitTrigger/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2020, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import useSubmitTrigger from './useSubmitTrigger';
+
+export default useSubmitTrigger;

--- a/src/hooks/useSubmitTrigger/useSubmitTrigger.spec.tsx
+++ b/src/hooks/useSubmitTrigger/useSubmitTrigger.spec.tsx
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+
+import { Events } from '../../types';
+import TrackingRoot from '../../components/TrackingRoot';
+
+import useSubmitTrigger from './useSubmitTrigger';
+
+const DispatchForm = () => {
+  const dispatch = useSubmitTrigger();
+
+  return (
+    <form
+      data-testid="dispatch-form"
+      onSubmit={(e) => {
+        e.preventDefault();
+
+        dispatch({
+          component: 'form'
+        });
+      }}
+    >
+      Dispatch button
+    </form>
+  );
+};
+
+describe('useSubmitTrigger', () => {
+  it('should provide a dispatch function that contains the submit event', () => {
+    const dispatch = jest.fn();
+    const app = 'test-app-hook';
+    const form = 'dispatch-form';
+    const component = 'form';
+
+    const expected = {
+      app,
+      view: undefined,
+      elementTree: [],
+      event: Events.submit,
+      component,
+      id: undefined,
+      timestamp: expect.any(Number)
+    };
+
+    const { getByTestId } = render(
+      <TrackingRoot name={app} onDispatch={dispatch}>
+        <DispatchForm />
+      </TrackingRoot>
+    );
+
+    fireEvent.submit(getByTestId(form));
+
+    expect(dispatch).toHaveBeenCalledWith(expected);
+  });
+});

--- a/src/hooks/useSubmitTrigger/useSubmitTrigger.ts
+++ b/src/hooks/useSubmitTrigger/useSubmitTrigger.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import useBaseTrigger from '../useBaseTrigger';
+import { Events } from '../../types';
+
+const useSubmitTrigger = () => useBaseTrigger(Events.submit);
+
+export default useSubmitTrigger;


### PR DESCRIPTION
## Approach and changes
- **Add useSubmitTrigger**: The hook is responsible for dispatching the `Events.submit` payload. 

It's expected to be used with forms, for example:

```jsx
import React from 'react';
import { useSubmitTrigger } from '@sumup/collector';

function Form({ children }) {
  const dispatch = useSubmitTrigger();

  const submitHandler = (e) => {
    e.preventDefault();

    dispatch({ component: 'form' });
  };

  return <form onSubmit={handler}>{children}</form>;
}
```

## Definition of done

* [x] Updated documentation
* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests