### PR TITLE
fix: memoize return value of useBaseTrigger 

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@testing-library/react-hooks": "^3.2.1",
     "@types/jest": "^26.0.15",
     "@types/react": "^16.9.56",
+    "@types/react-dom": "^17.0.0",
     "cz-conventional-changelog": "3.3.0",
     "jest": "^26.6.3",
     "react": "^17.0.1",

--- a/src/hooks/useBaseTrigger/useBaseTrigger.ts
+++ b/src/hooks/useBaseTrigger/useBaseTrigger.ts
@@ -23,18 +23,23 @@ const useBaseTrigger = (event: Events) => {
     TrackingContext
   );
 
-  return ({ component, label, customParameters }: Dispatch) =>
-    dispatch &&
-    dispatch({
-      app,
-      view,
-      elementTree,
-      event,
-      component,
-      label,
-      timestamp: Date.now(),
-      customParameters
-    });
+  const handleTrigger = React.useCallback(
+    ({ component, label, customParameters }: Dispatch) =>
+      dispatch &&
+      dispatch({
+        app,
+        view,
+        elementTree,
+        event,
+        component,
+        label,
+        timestamp: Date.now(),
+        customParameters
+      }),
+    [app, dispatch, elementTree, event, view]
+  );
+
+  return handleTrigger;
 };
 
 export default useBaseTrigger;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1244,6 +1244,13 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
+"@types/react-dom@^17.0.0":
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.0.tgz#b3b691eb956c4b3401777ee67b900cb28415d95a"
+  integrity sha512-lUqY7OlkF/RbNtD5nIq7ot8NquXrdFrjSOR6+w9a9RFQevGi1oZO1dcJbXMeONAPKtZ2UrZOEJ5UOCVsxbLk/g==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-test-renderer@*":
   version "16.9.3"
   resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.3.tgz#96bab1860904366f4e848b739ba0e2f67bcae87e"
@@ -7034,7 +7041,6 @@ npm@^6.14.8:
     cmd-shim "^3.0.3"
     columnify "~1.5.4"
     config-chain "^1.1.12"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -7049,7 +7055,6 @@ npm@^6.14.8:
     has-unicode "~2.0.1"
     hosted-git-info "^2.8.8"
     iferr "^1.0.2"
-    imurmurhash "*"
     infer-owner "^1.0.4"
     inflight "~1.0.6"
     inherits "^2.0.4"
@@ -7068,14 +7073,8 @@ npm@^6.14.8:
     libnpx "^10.2.4"
     lock-verify "^2.1.0"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"


### PR DESCRIPTION
Fixes #30.

Wrap the dispatch function returned by `useBaseTrigger` into `useCallback` to memoize it. This makes it possible to send events in a `useEffect` hook. Previously, the function would be recreated on every render, thus falsy triggering the `useEffect`.