### PR TITLE
fix: add payload type to dispatch

### DIFF
--- a/src/components/TrackingRoot/TrackingRoot.tsx
+++ b/src/components/TrackingRoot/TrackingRoot.tsx
@@ -15,11 +15,11 @@
 
 import * as React from 'react';
 
-import { TrackingProviderProps as ProviderProps } from '../../types';
+import { TrackingProviderProps as ProviderProps, Payload } from '../../types';
 import TrackingContext from '../TrackingContext';
 
 type Props = ProviderProps & {
-  onDispatch?: () => void;
+  onDispatch?: (payload: Payload) => void;
 };
 
 const TrackingRoot = ({ name, onDispatch, children }: Props) => {


### PR DESCRIPTION
## Purpose

@bogdanlupuro reported a TypeScript error when passing the `dispatch` function to the `TrackingRoot`:

![Type '(event: any) => void' is not assignable to type '() => void'.](https://user-images.githubusercontent.com/11017722/103664539-ae0ebe80-4f72-11eb-
9a9d-30a6525d1865.png)

## Approach & Changes

- Add missing type for dispatch payload