### PR TITLE
feat: export TrackingContext

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@
  */
 
 import TrackingRoot from './components/TrackingRoot';
+import TrackingContext from './components/TrackingContext';
 import TrackingView from './components/TrackingView';
 import TrackingElement from './components/TrackingElement';
 import useClickTrigger from './hooks/useClickTrigger';
@@ -24,6 +25,7 @@ import * as Types from './types';
 
 export {
   TrackingRoot,
+  TrackingContext,
   TrackingView,
   TrackingElement,
   useClickTrigger,


### PR DESCRIPTION
I'm creating a TrackingView wrapper from a consumer, and I would like to mock and check the view is set properly in the context so that I can check it's sending the proper name, as well as maybe get the current value for logging, for testing purposes.

This is the more flexible but simple way I found to do it.

Note: I tried with setting up a local reference to collector with local changes, but is not so easy as it has a duplicate version of react and all that story that throw errors on hooks. Also, modifying the source is very awkward since is only bundled and obfuscated.