### PR TITLE
fix(hooks): prevent duplicated page view events

### DIFF
--- a/src/hooks/usePageViewTrigger/usePageViewTrigger.ts
+++ b/src/hooks/usePageViewTrigger/usePageViewTrigger.ts
@@ -13,13 +13,17 @@
  * limitations under the License.
  */
 
+import * as React from 'react';
+
 import useBaseTrigger from '../useBaseTrigger';
 import { Events } from '../../types';
 
 const usePageViewTrigger = () => {
   const dispatch = useBaseTrigger(Events.pageView);
 
-  return () => dispatch({});
+  const handleTrigger = React.useCallback(() => dispatch({}), [dispatch]);
+
+  return handleTrigger;
 };
 
 export default usePageViewTrigger;


### PR DESCRIPTION
Addresses [OT-332](https://sumupteam.atlassian.net/browse/OT-332).

## Purpose

The `usePageViewTrigger` fired multiple times when used inside a `useEffect` hook, leading to duplicated events. This happened because the function returned by `usePageViewTrigger` was recreated on every render.

## Approach & Changes

- wrap the page view trigger in `useCallback`