### PR TITLE
fix: remove lint:ci and change lint task on ci.yml to not use GH formatter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: yarn --pure-lockfile --prefer-offline
       - name: Lint
-        run: yarn lint:ci
+        run: yarn lint
       - name: Build
         run: yarn build
       - name: Unit testing

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "test:ci": "jest --ci --coverage",
     "lint": "foundry run eslint . --ext .js,.jsx,.json,.ts,.tsx",
     "lint:fix": "yarn lint --fix",
-    "lint:ci": "yarn lint --format github",
     "prerelease": "yarn build",
     "release": "foundry run semantic-release"
   },


### PR DESCRIPTION
Relates to https://github.com/sumup-oss/foundry/issues/827.

## Purpose

> You use the library (eslint-formatter-github) in several repositories, which has a hard-coded private key to the authorized GitHub app in the source code. This is a possible security vulnerability. The certificate gives every user read/write permissions to your GitHub actions check. In addition, metadata from non-public repositories can also be viewed.

## Approach and changes

- Stop using `eslint-formatter-github` and revoke access to the repository